### PR TITLE
Example 1: qemu aarch64 bare metal bootup

### DIFF
--- a/arm64/Readme.md
+++ b/arm64/Readme.md
@@ -1,0 +1,6 @@
+## Install KVM on Raspberry Pi 4 (Debian 0S)
+`sudo apt install qemu-system-arm`
+
+## For cross compilation 
+- install toolchain `aarch64-none-elf-*` from linaro 
+

--- a/arm64/qemu-arm64/.gitignore
+++ b/arm64/qemu-arm64/.gitignore
@@ -1,0 +1,2 @@
+qemu_arm64_test.elf
+*.o

--- a/arm64/qemu-arm64/Makefile
+++ b/arm64/qemu-arm64/Makefile
@@ -1,0 +1,25 @@
+CC=aarch64-none-elf-gcc
+LD=aarch64-none-elf-ld
+
+all: clean build
+
+build: boot.o qemu_arm64.o
+	$(LD) -T linker.ld boot.o qemu_arm64.o -o qemu_arm64_test.elf
+
+boot.o: boot.s
+	$(CC) -c $^ -o $@
+
+qemu_arm64.o: qemu_arm64.c
+	$(CC) -c $^ -o $@
+
+clean:
+	rm -rf boot.o
+	rm -rf qemu_arm64.o
+	rm -rf qemu_arm64_test.elf
+
+run:
+#on Aarch64 device
+	qemu-system-aarch64 -M virt -cpu host -enable-kvm -nographic -kernel qemu_arm64_test.elf
+#other platform we need to emulation
+	qemu-system-aarch64 -M virt -cpu cortex-a72 -nographic -kernel qemu_arm64_test.elf
+	

--- a/arm64/qemu-arm64/boot.s
+++ b/arm64/qemu-arm64/boot.s
@@ -1,0 +1,14 @@
+.global _start
+_start:
+    ldr x30, =stack_top	    /* Retrieve initial stack address */
+    mov sp, x30             /* Set stack address */
+    bl main                 /* Branch to main() */
+
+.global system_off
+system_off:
+    ldr x0, =0x84000008     /* SYSTEM_OFF function ID */
+    hvc #0                  /* Hypervisor call */
+
+sleep:                      /* This point should not be reached */
+    wfi                     /* Wait for interrupt */
+    b sleep                 /* Endless loop */

--- a/arm64/qemu-arm64/linker.ld
+++ b/arm64/qemu-arm64/linker.ld
@@ -1,0 +1,13 @@
+ENTRY(_start)
+
+SECTIONS
+{
+	. = 0x40000000;
+	.boot . : { boot.o(.text) }
+	.text : { *(.text) }
+	.data : { *(.data) }
+	.bss : { *(.bss COMMON) }
+	. = ALIGN(16);
+	. = . + 0x1000; /* 4kB of stack memory */
+	stack_top = .;
+}

--- a/arm64/qemu-arm64/qemu_arm64.c
+++ b/arm64/qemu-arm64/qemu_arm64.c
@@ -1,0 +1,14 @@
+/*For Qemu Virt Aarch64 Arm SOC*/
+/*https://github.com/qemu/qemu/blob/master/hw/arm/virt.c#L147C6-L147C15*/
+volatile unsigned int * const UART0DR = (unsigned int *) 0x09000000;
+ 
+void print_uart0(const char *s) {
+    while(*s != '\0') { 		/* Loop until end of string */
+         *UART0DR = (unsigned int)(*s); /* Transmit char */
+          s++;			        /* Next char */
+    }
+}
+ 
+void main() {
+     print_uart0("Hello what's up!\n");
+}


### PR DESCRIPTION
- print via uart
- tested with enable-kvm on raspi 4 8GB